### PR TITLE
Support new WSL iface name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.21
 
     - name: Build
       run: go build -v ./...

--- a/fix_routes.go
+++ b/fix_routes.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package main
 
@@ -9,16 +9,26 @@ import (
 	"github.com/wheatevo/wslroutesvc/runner"
 )
 
-func fixRoutes(wslIfaceName string, runner runner.Runner) {
-	wslIface := network.NewIface(wslIfaceName, runner)
+func fixRoutes(wslIfaceNames []string, runner runner.Runner) {
+	var wslIface network.Iface
+	var wslIfaceName string
+	foundIface := false
 
-	if wslIface.ID == "" {
-		elog.Error(1, fmt.Sprintf("Could not find interface ID for WSL interface %s", wslIfaceName))
-		return
+	// Iterate through possible WSL interface names to find a valid interface
+	for _, ifaceName := range wslIfaceNames {
+		wslIface = network.NewIface(ifaceName, runner)
+
+		if wslIface.ID == "" || wslIface.IP.String() == "<nil>" {
+			continue
+		}
+
+		wslIfaceName = ifaceName
+		foundIface = true
+		break
 	}
 
-	if wslIface.IP.String() == "<nil>" {
-		elog.Error(1, fmt.Sprintf("Could not find interface IP for WSL interface %s", wslIfaceName))
+	if !foundIface {
+		elog.Error(1, fmt.Sprintf("Could not find interface ID or IP for WSL interfaces ", wslIfaceNames))
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/wheatevo/wslroutesvc
 
-go 1.15
+go 1.21
 
-require golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78
+require golang.org/x/sys v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
-golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/install.go
+++ b/install.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -1,11 +1,10 @@
-// +build windows
+//go:build windows
 
 // Windows service for fixing WSL/VPN Routing conflicts automatically
 //
 // This service searches for routing conflicts caused by a VPN and
 // removes any routes that overlap with the WSL network interface
 // to avoid WSL networking failure.
-//
 package main
 
 import (

--- a/manage.go
+++ b/manage.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package main
 

--- a/service.go
+++ b/service.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package main
 
@@ -34,7 +34,9 @@ loop:
 		case <-tick:
 			currentTime = time.Now()
 			if currentTime.After(lastFixTime.Add(10 * time.Second)) {
-				fixRoutes("vEthernet (WSL)", &runner)
+				// Versions after 2.0.5.0:  vEthernet (WSL (Hyper-V firewall))
+				// Versions before 2.0.5.0: vEthernet (WSL)
+				fixRoutes([]string{"vEthernet (WSL)", "vEthernet (WSL (Hyper-V firewall))"}, &runner)
 				lastFixTime = time.Now()
 			}
 		case c := <-r:


### PR DESCRIPTION
Make changes to support a new WSL interface name.

The name changed from:

`vEthernet (WSL)`

to:

`vEthernet (WSL (Hyper-V firewall))`

in version 2.0.5.0 of WSL.

Also includes a bump to golang 1.21.